### PR TITLE
Resolve #1 "Zesty is EOL (thus the build fails!) "

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-FROM ubuntu:17.04
+FROM ubuntu:17.10
 
 
 # see https://atom.io/releases


### PR DESCRIPTION
Resolve #1 

-> base the docker image on top of Ubuntu 17.10 instead of 17.04 that is End Of Life

> It seems working without requiring any change